### PR TITLE
Add attributes to sub nav

### DIFF
--- a/js/jquery-accessibleMegaMenu.js
+++ b/js/jquery-accessibleMegaMenu.js
@@ -876,6 +876,7 @@ limitations under the License.
                         // Add attributes to sub nav.
                         topnavitempanel.attr({
                             "role": "region",
+                            "aria-expanded": false,
                             "aria-hidden": true
                         })
                         .addClass(settings.panelClass)


### PR DESCRIPTION
**Desired functionality:** If the menu has a list of items, then it is supposed to open the list on key press "Enter" and if opend already then close the list on key press "Enter"
**Resolved:** by adding <"aria-expanded": false,> in <topnavitempanel.attr({.....>